### PR TITLE
Fix Liquid syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@ layout: default
     <div class="col-md-8 offset-md-2">
       {% assign categories = site.categories | sort %}
       {% for category in categories %}
-      <h3>On {{ category || first }}</h3>
+      <h3>On {{ category | first }}</h3>
       <p>{% for posts in category %} {% for post in posts %}
             <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>{% if forloop.last == false %},&nbsp;&nbsp;{% endif %}
         {% endfor %} {% endfor %}  </p>


### PR DESCRIPTION
`||` is not valid Liquid (see https://github.com/Shopify/liquid/issues/538). With Jekyll 3.3 (at least), the invalid syntax throws the error as seen in #1 